### PR TITLE
Clean byte-compile and checkdoc warnings

### DIFF
--- a/screenshot.el
+++ b/screenshot.el
@@ -74,7 +74,7 @@ Then the text of the region/buffer is uploaded, and the URL is copied to clipboa
     (screenshot--set-screenshot-region beg end)
     (setq screenshot--tmp-file
           (make-temp-file "screenshot-" nil ".png"))
-    (screenshot-transient)))
+    (call-interactively #'screenshot-transient)))
 
 (defun screenshot-text-upload (beg end)
   "Upload the region from BEG to END, and copy the upload URL to the clipboard."
@@ -238,15 +238,15 @@ Must take a single argument, the file name, and operate in-place."
                     screenshot-shadow-offset-horizontal
                     screenshot-shadow-offset-vertical))))
       (unless (string= result "")
-        (error "Could not apply imagemagick commants to image:\n%s" result))))
+        (error "Could not apply imagemagick commands to image:\n%s" result))))
   (run-hook-with-args 'screenshot-post-process-hook file))
 
 ;;; Screenshot actions
 
 (defmacro screenshot--def-action (name &rest body)
-  "Define an action that may be performed on a screenshot from the transient interface.
+  "Define action NAME to be performed from the transient interface.
 BODY is executed after `screenshot-process' is called."
-  `(defun ,(intern (concat "screenshot-" name)) (&optional args)
+  `(defun ,(intern (concat "screenshot-" name)) (&optional _args)
      "Screenshot action to be performed from the transient interface."
      (interactive
       (list (transient-args 'screenshot-transient)))
@@ -331,7 +331,9 @@ Note: you have to define this yourself, there is no default."
    ("c" "Copy" screenshot-copy)
    ("u" "Upload" screenshot-upload)])
 
-(defmacro screenshot--define-infix (key name description type default &rest reader)
+(defmacro screenshot--define-infix (key name description type default
+					&rest reader)
+  "Define infix with KEY, NAME, DESCRIPTION, TYPE, DEFAULT and READER as arguments."
   `(progn
      (defcustom ,(intern (concat "screenshot-" name)) ,default
        ,description
@@ -367,6 +369,10 @@ Note: you have to define this yourself, there is no default."
  "-T" "truncate-lines-p" "Truncate lines beyond the screenshot width"
  'boolean nil
  (not screenshot-truncate-lines-p))
+
+(declare-function counsel-fonts "ext:counsel-fonts")
+
+(declare-function ivy-read "ext:ivy-read")
 
 (screenshot--define-infix
  "-ff" "font-family" "Font family to use"


### PR DESCRIPTION
Hi, I've known about this package in [reddit](https://www.reddit.com/r/emacs/comments/ngbt2j/offer_collaboration/) and I like it very much. Congratulations! 

I would like to help you to put it on melpa.

In my first review, I have not seen any bug. My byte-compile (Emacs 28.0) throw this warnings:

In screenshot:
screenshot.el:75:11: Warning: ‘screenshot-transient’ is for
interactive use only.

In screenshot-save:
screenshot.el:256:1: Warning: Unused lexical argument `args'

In screenshot-save-as:
screenshot.el:267:1: Warning: Unused lexical argument `args'

In screenshot-copy:
screenshot.el:275:1: Warning: Unused lexical argument `args'

In screenshot-upload:
screenshot.el:293:1: Warning: Unused lexical argument `args'

In end of data:
screenshot.el:375:7: Warning: the function ‘ivy-read’ is not known to
be defined.
screenshot.el:374:17: Warning: the function ‘counsel-fonts’ is not
known to be defined.

After little changes I have no warnings in byte-compile, checkdoc and package-lint.

I would like to know if there are more things to do in this packages so I help to improve it or to put it on Melpa (although it's fine!).

Sergi