### PR TITLE
Fix bug: No key for screenshot--set-line-numbers-p

### DIFF
--- a/screenshot.el
+++ b/screenshot.el
@@ -68,7 +68,7 @@ Run after hardcoded setup, but before the screenshot is captured."
 
 ;;; Screenshot parameters
 
-(eval-when-compile
+(eval-and-compile
   (defmacro screenshot--define-infix (key name description type default
                                           &rest reader)
     "Define infix with KEY, NAME, DESCRIPTION, TYPE, DEFAULT and READER as arguments."
@@ -367,7 +367,7 @@ Must take a single argument, the file name, and operate in-place."
 
 ;;; Screenshot actions
 
-(eval-when-compile
+(eval-and-compile
   (defmacro screenshot--def-action (name &rest body)
     "Define action NAME to be performed from the transient interface.
 BODY is executed after `screenshot-process' is called."


### PR DESCRIPTION
Use eval-and-compile instead of eval-when-compile to ensure the code is
also run when loaded. Addresses #11 