### PR TITLE
Add options to set screenshot's metadata

### DIFF
--- a/screenshot.el
+++ b/screenshot.el
@@ -146,6 +146,11 @@ READER."
     "Set image \"title\" metadata to `buffer-name'"
     'boolean t)
 
+(screenshot--define-infix
+    "-ma" user-full-name-as-image-author-p
+    "Set image \"author\" metadata to `user-full-name'"
+    'boolean nil)
+
 (declare-function counsel-fonts "ext:counsel-fonts")
 
 (declare-function ivy-read "ext:ivy-read")
@@ -460,6 +465,8 @@ Must take a single argument, the file name, and operate in-place."
                                                      screenshot--region-end)))
                     (and screenshot-buffer-name-as-image-title-p
                          (list "-set" "title" (buffer-name)))
+                    (and screenshot-user-full-name-as-image-author-p
+                         (list "-set" "author" user-full-name))
                     (list
                      "-background" "none"
                      "-layers" "merge"
@@ -628,7 +635,8 @@ return a URL."
    (screenshot--set-shadow-offset-vertical)]
   ["Metadata"
    (screenshot--set-code-as-image-description-p)
-   (screenshot--set-buffer-name-as-image-title-p)]
+   (screenshot--set-buffer-name-as-image-title-p)
+   (screenshot--set-user-full-name-as-image-author-p)]
   ["Action"
    ["Save"
     ("s" "Save image" screenshot-save)

--- a/screenshot.el
+++ b/screenshot.el
@@ -29,13 +29,14 @@
 ;;; Commentary:
 
 ;; Convenience package for creating images of the current region or buffer.
-;; Requires `imagemagick' for some visual post-processing, and `xclip' for
-;; copying images to the clipboard.
+;; Requires `imagemagick' to set metadata and for some visual post-processing,
+;; and `xclip' for copying images to the clipboard.
 
 ;;; Code:
 
 (require 'transient)
 (require 'posframe)
+(require 'lisp-mnt)
 
 (defgroup screenshot ()
   "Customise group for Screenshot."
@@ -446,6 +447,9 @@ Must take a single argument, the file name, and operate in-place."
                     (list
                      "-background" "none"
                      "-layers" "merge"
+                     "-set" "software" (format "Emacs %s; screenshot.el %s"
+                                               emacs-version
+                                               (lm-version (symbol-file 'screenshot)))
                      file))))))
       (unless (eq result 0)
         (error "Could not apply imagemagick commands to image (exit code %d)" result))))

--- a/screenshot.el
+++ b/screenshot.el
@@ -136,6 +136,11 @@ READER."
     "Remove indent in selection"
     'boolean t)
 
+(screenshot--define-infix
+    "-md" code-as-image-description-p
+    "Set \"description\" metadata to text in region"
+    'boolean t)
+
 (declare-function counsel-fonts "ext:counsel-fonts")
 
 (declare-function ivy-read "ext:ivy-read")
@@ -444,6 +449,10 @@ Must take a single argument, the file name, and operate in-place."
                                                  screenshot-shadow-offset-horizontal
                                                  screenshot-shadow-offset-vertical)
                                ")" "+swap"))
+                    (and screenshot-code-as-image-description-p
+                         (list "-set" "description" (buffer-substring
+                                                     screenshot--region-beginning
+                                                     screenshot--region-end)))
                     (list
                      "-background" "none"
                      "-layers" "merge"
@@ -610,6 +619,8 @@ return a URL."
    (screenshot--set-shadow-color)
    (screenshot--set-shadow-offset-horizontal)
    (screenshot--set-shadow-offset-vertical)]
+  ["Metadata"
+   (screenshot--set-code-as-image-description-p)]
   ["Action"
    ["Save"
     ("s" "Save image" screenshot-save)

--- a/screenshot.el
+++ b/screenshot.el
@@ -141,6 +141,11 @@ READER."
     "Set \"description\" metadata to text in region"
     'boolean t)
 
+(screenshot--define-infix
+    "-mt" buffer-name-as-image-title-p
+    "Set image \"title\" metadata to `buffer-name'"
+    'boolean t)
+
 (declare-function counsel-fonts "ext:counsel-fonts")
 
 (declare-function ivy-read "ext:ivy-read")
@@ -453,6 +458,8 @@ Must take a single argument, the file name, and operate in-place."
                          (list "-set" "description" (buffer-substring
                                                      screenshot--region-beginning
                                                      screenshot--region-end)))
+                    (and screenshot-buffer-name-as-image-title-p
+                         (list "-set" "title" (buffer-name)))
                     (list
                      "-background" "none"
                      "-layers" "merge"
@@ -620,7 +627,8 @@ return a URL."
    (screenshot--set-shadow-offset-horizontal)
    (screenshot--set-shadow-offset-vertical)]
   ["Metadata"
-   (screenshot--set-code-as-image-description-p)]
+   (screenshot--set-code-as-image-description-p)
+   (screenshot--set-buffer-name-as-image-title-p)]
   ["Action"
    ["Save"
     ("s" "Save image" screenshot-save)


### PR DESCRIPTION
Adds options for basic screenshot metadata manipulation:

- Always sets the "software" field to the current version of Emacs and screenshot.el
- By default, sets the "description" field to the text captured in the screenshot (`-md` to toggle)
- By default, sets the "title" to the buffer name in which the screenshot'd text resides (`-mt` to toggle)
- Optionally sets "author" to `user-full-name` (`-ma` to toggle)