### PR TITLE
update make-indirect-buffer to have right num of args

### DIFF
--- a/screenshot.el
+++ b/screenshot.el
@@ -308,7 +308,7 @@ This buffer then then set up to be used for a screenshot."
   (let ((hl (bound-and-true-p hl-line-mode)))
     (when hl (hl-line-mode -1))
     (prog1
-        (with-current-buffer (make-indirect-buffer (current-buffer) " *screenshot-clone" t t)
+        (with-current-buffer (make-indirect-buffer (current-buffer) " *screenshot-clone" t)
           (narrow-to-region beg end)
           (screenshot--setup-buffer)
           (buffer-face-set :family screenshot-font-family


### PR DESCRIPTION
I am on Emacs 27.2 and had to make this change to get it working. I assume `make-indirect-buffer` is a core function, so this discrepancy is a bit surprising...

Great package btw.